### PR TITLE
feat: fetch balance directly from account and contract address

### DIFF
--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -8,8 +8,16 @@ import {
   Flex,
   Heading,
 } from '@pancakeswap-libs/uikit';
-import { selectTokensAmount } from '@store/information';
-import type { TokenAmount } from '@pancakeswap-libs/sdk';
+import { selectTokensData } from '@store/information';
+import {
+  Currency,
+  CurrencyAmount,
+  Fraction,
+  JSBI,
+  Token,
+  TokenAmount,
+} from '@pancakeswap-libs/sdk';
+import { STokenAmount } from '@models/utils/serializable-types';
 
 const ResultContainer = styled.div`
   width: 100%;
@@ -22,29 +30,40 @@ const ResultContainer = styled.div`
 
 interface IResultProps {}
 export const Result = (props: IResultProps) => {
-  const tokensAmount = useSelector(selectTokensAmount);
-  /*
-  const tokens = Object.entries<TokenAmount>(tokensAmount);
+  const tokensData = useSelector(selectTokensData);
+  const sTokens =
+    tokensData?.tokens && Object.entries<STokenAmount>(tokensData.tokens);
+  const tokens = sTokens?.map(([k, v]) => [
+    k,
+    new TokenAmount(
+      new Token(
+        v.token.chainId,
+        v.token.address,
+        v.token.decimals,
+        v.token.symbol,
+        v.token.name,
+      ),
+      v.numerator,
+    ),
+  ]) as [string, TokenAmount][] | undefined;
+  const sBNBAmount = useSelector(selectTokensData).BNBAmount;
+  const BNBAmount = sBNBAmount && CurrencyAmount.ether(sBNBAmount.numerator);
   const items = tokens
-    .sort(
-      (a, b) =>
-        b[1].amount * Number(b[1].price?.price ?? 0) -
-        a[1].amount * Number(a[1].price?.price ?? 0),
-    )
-    .map(([contract, { amount, price }]) => {
+    ?.sort((a, b) => (b[1].lessThan(a[1]) ? -1 : 1))
+    ?.map(([contract, tokenAmount]) => {
       return (
-        price &&
-        amount * Number(price.price) > 0.01 && (
+        tokenAmount &&
+        tokenAmount.greaterThan(
+          new Fraction(JSBI.BigInt(1), JSBI.BigInt(1000000)),
+        ) && (
           <div key={contract}>
             <RegularCard>
               <CardBody>
                 <Heading color="contrast">
-                  {price.name} ({price.symbol})
+                  {tokenAmount.token.name} ({tokenAmount.token.symbol})
                 </Heading>
                 <Flex justifyContent="space-between">
-                  <CardMidContent>
-                    $ {(amount * Number(price.price)).toFixed(2)}
-                  </CardMidContent>
+                  <CardMidContent>{tokenAmount.toFixed(6)}</CardMidContent>
                   <ArrowForwardIcon mt={30} color="primary" />
                 </Flex>
               </CardBody>
@@ -53,19 +72,20 @@ export const Result = (props: IResultProps) => {
         )
       );
     });
-    */
   return (
     <ResultContainer>
       <SpecialCard>
         <CardBody>
           <Heading color="contrast">Binance Coin (BNB)</Heading>
           <Flex justifyContent="space-between">
-            <CardMidContent color="invertedContrast">$ BNBPRICE</CardMidContent>
+            <CardMidContent color="invertedContrast">
+              $ {BNBAmount?.toFixed(6)}
+            </CardMidContent>
             <ArrowForwardIcon mt={30} color="primary" />
           </Flex>
         </CardBody>
       </SpecialCard>
-      ITEMS
+      {items}
     </ResultContainer>
   );
 };

--- a/src/models/token/types.ts
+++ b/src/models/token/types.ts
@@ -1,7 +1,0 @@
-import type { CurrencyAmount, TokenAmount } from '@pancakeswap-libs/sdk';
-
-export interface TokensData {
-  tokens: Record<string, TokenAmount>;
-  BNBAmount: CurrencyAmount;
-  fee: CurrencyAmount;
-}

--- a/src/models/utils/serializable-types.ts
+++ b/src/models/utils/serializable-types.ts
@@ -1,0 +1,26 @@
+import { ChainId } from '@pancakeswap-libs/sdk';
+import JSBI from 'jsbi';
+
+export interface SFraction {
+  numerator: JSBI;
+  denominator: JSBI;
+}
+
+export interface SCurrency {
+  decimals: number;
+  symbol?: string;
+  name?: string;
+}
+
+export interface SCurrencyAmount extends SFraction {
+  currency: SCurrency;
+}
+
+export interface SToken extends SCurrency {
+  readonly chainId: ChainId;
+  readonly address: string;
+}
+
+export interface STokenAmount extends SCurrencyAmount {
+  token: SToken;
+}

--- a/src/store/information/index.ts
+++ b/src/store/information/index.ts
@@ -1,5 +1,15 @@
-import type { TokensData } from '@models/token';
+import { BigintIsh } from '@pancakeswap-libs/sdk';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import {
+  SCurrencyAmount,
+  STokenAmount,
+} from '@models/utils/serializable-types';
+
+export interface TokensData {
+  tokens: Record<string, STokenAmount>;
+  BNBAmount: SCurrencyAmount;
+  fee: SCurrencyAmount;
+}
 
 export const informationSlices = createSlice({
   name: 'information',
@@ -8,7 +18,7 @@ export const informationSlices = createSlice({
     error: '',
   },
   reducers: {
-    requestTokensData: (state) => state,
+    tokensDataRequested: (state) => state,
     tokensDataReceived: (state, action: PayloadAction<TokensData>) => ({
       ...state,
       tokensData: action.payload,
@@ -20,7 +30,7 @@ export const informationSlices = createSlice({
   },
 });
 
-export const { requestTokensData, tokensDataReceived, tokensDataFailed } =
+export const { tokensDataRequested, tokensDataReceived, tokensDataFailed } =
   informationSlices.actions;
 
 export * from './selectors';

--- a/src/store/information/sagas.ts
+++ b/src/store/information/sagas.ts
@@ -1,32 +1,20 @@
-import { fetchTokensDataFromUserInfo, TokensData } from '@models/token';
+import { fetchTokensDataFromUserInfo } from '@models/token';
+import { all, call, put, select, takeLatest } from '@redux-saga/core/effects';
 import {
-  all,
-  call,
-  put,
-  race,
-  select,
-  takeLatest,
-} from '@redux-saga/core/effects';
-import {
-  BEP20TransactionsReceived,
-  BNBTransactionsReceived,
-  internalTransactionsReceived,
+  BEP20AmountsReceived,
+  BNBAmountsReceived,
   selectUserInfo,
 } from '@store/transactions';
 import type { UserInfo } from '@store/transactions/types';
-import { requestTokensData, tokensDataReceived } from '.';
+import { tokensDataRequested, tokensDataReceived } from '.';
+import type { TokensData } from '.';
 
 function* watchFetchTokensData() {
-  yield takeLatest(
-    [
-      BEP20TransactionsReceived,
-      BNBTransactionsReceived,
-      internalTransactionsReceived,
-    ],
-    fetchTokens,
-  );
+  yield takeLatest([BEP20AmountsReceived, BNBAmountsReceived], fetchTokens);
 }
+
 function* fetchTokens() {
+  yield put(tokensDataRequested());
   const userInfo: UserInfo = yield select(selectUserInfo);
   const tokensData: TokensData = yield call(
     fetchTokensDataFromUserInfo,
@@ -36,5 +24,5 @@ function* fetchTokens() {
 }
 
 export default function* rootSaga() {
-  yield watchFetchTokensData();
+  yield all([watchFetchTokensData()]);
 }

--- a/src/store/information/selectors.ts
+++ b/src/store/information/selectors.ts
@@ -1,11 +1,4 @@
-import { ChainId, Fetcher, Token } from '@pancakeswap-libs/sdk';
 import type { RootState } from '@store';
-import { selectUserInfo } from '@store/transactions';
-import { createSelector } from 'reselect';
 
 export const selectTokensData = (state: RootState) =>
   state.information.tokensData;
-export const selectTokensAmount = createSelector(
-  selectTokensData,
-  ({ tokens }) => tokens,
-);

--- a/src/store/transactions/BEP20/selectors.ts
+++ b/src/store/transactions/BEP20/selectors.ts
@@ -1,13 +1,35 @@
 import type { RootState } from '@store';
-import { selectAddress } from '@store/address';
 import { createSelector } from 'reselect';
-import { parseBEP20Transactions } from '@utils/transactions';
+import {
+  IRawBEP20Transaction,
+  UserBEP20TokensInfo,
+} from '@models/transactions';
+import { BigintIsh, JSBI } from '@pancakeswap-libs/sdk';
 
 export const selectRawBEP20Transactions = (state: RootState) =>
   state.transactions.BEP20Transactions;
+export const selectBEP20Amounts = (state: RootState) =>
+  state.transactions.BEP20Amounts;
+/*
+This old method retrieves info from transactions.
 
 export const selectUserBEP20TokensInfo = createSelector(
   selectRawBEP20Transactions,
   selectAddress,
   parseBEP20Transactions,
+);
+*/
+
+export const selectUserBEP20Tokens = createSelector(
+  selectRawBEP20Transactions,
+  (txns: IRawBEP20Transaction[]) =>
+    Array.from(new Set<string>(txns.map((txn) => txn.contractAddress))),
+);
+
+export const selectUserBEP20TokensInfo = createSelector(
+  selectBEP20Amounts,
+  (amts: Record<string, BigintIsh>): UserBEP20TokensInfo => ({
+    tokens: amts,
+    fee: JSBI.BigInt(0),
+  }),
 );

--- a/src/store/transactions/BNB/selectors.ts
+++ b/src/store/transactions/BNB/selectors.ts
@@ -1,4 +1,35 @@
+import { UserBNBTokenInfo } from '@models/transactions';
+import { BigintIsh, JSBI } from '@pancakeswap-libs/sdk';
 import type { RootState } from '@store';
+import { createSelector } from 'reselect';
 
 export const selectRawBNBTransactions = (state: RootState) =>
   state.transactions.BNBTransactions;
+
+export const selectBNBAmounts = (state: RootState) =>
+  state.transactions.BNBAmounts;
+
+export const selectUserBNBTokenInfo = createSelector(
+  selectBNBAmounts,
+  (amt: BigintIsh): UserBNBTokenInfo => ({
+    amount: amt,
+    fee: JSBI.BigInt(0),
+  }),
+);
+
+/*
+export const selectUserBNBTokenInfo = createSelector(
+  selectRawBNBTransactions,
+  selectRawInternalTransactions,
+  selectAddress,
+  (BNBTxns, internalTxns, address) => {
+    const result = parseBNBTransactions(BNBTxns, address);
+    result.amount = JSBI.add(
+      parseBigintIsh(result.amount),
+      parseBigintIsh(parseInternalTransactions(internalTxns, address).amount),
+    );
+    // no fees in internal transactions
+    return result;
+  },
+);
+*/

--- a/src/store/transactions/index.ts
+++ b/src/store/transactions/index.ts
@@ -5,6 +5,7 @@ import type {
   IRawBNBTransaction,
   IRawInternalTransaction,
 } from '@models/transactions/types';
+import { BigintIsh, JSBI } from '@pancakeswap-libs/sdk';
 
 export const transactionsSlice = createSlice({
   name: 'transactions',
@@ -12,6 +13,8 @@ export const transactionsSlice = createSlice({
     BEP20Transactions: [] as IRawBEP20Transaction[],
     BNBTransactions: [] as IRawBNBTransaction[],
     internalTransactions: [] as IRawInternalTransaction[],
+    BEP20Amounts: {} as Record<string, BigintIsh>,
+    BNBAmounts: JSBI.BigInt(0) as BigintIsh,
     error: '',
   },
   reducers: {
@@ -51,6 +54,25 @@ export const transactionsSlice = createSlice({
       ...state,
       error: action.payload,
     }),
+    BEP20AmountsReceived: (
+      state,
+      action: PayloadAction<Record<string, BigintIsh>>,
+    ) => ({
+      ...state,
+      BEP20Amounts: action.payload,
+    }),
+    BEP20AmountsFailed: (state, action: PayloadAction<string>) => ({
+      ...state,
+      error: action.payload,
+    }),
+    BNBAmountsReceived: (state, action: PayloadAction<BigintIsh>) => ({
+      ...state,
+      BNBAmounts: action.payload,
+    }),
+    BNBAmountsFailed: (state, action: PayloadAction<string>) => ({
+      ...state,
+      error: action.payload,
+    }),
   },
 });
 
@@ -64,6 +86,10 @@ export const {
   requestInternalTransactions,
   internalTransactionsReceived,
   internalTransactionsFailed,
+  BEP20AmountsReceived,
+  BEP20AmountsFailed,
+  BNBAmountsReceived,
+  BNBAmountsFailed,
 } = transactionsSlice.actions;
 
 export * from './selectors';

--- a/src/store/transactions/sagas.ts
+++ b/src/store/transactions/sagas.ts
@@ -1,8 +1,31 @@
-import { all, takeLatest } from '@redux-saga/core/effects';
+import {
+  all,
+  takeLatest,
+  call,
+  put,
+  select,
+  takeEvery,
+} from '@redux-saga/core/effects';
 import { requestBEP20Transactions, requestBNBTransactions } from '.';
 
 import { requestBEP20 } from './BEP20/sagas';
 import { requestBNB } from './BNB/sagas';
+import { BigintIsh, JSBI } from '@pancakeswap-libs/sdk';
+import { selectAddress } from '@store/address';
+import { fetchBEP20Balance } from '../../tests/utils/fetchBEP20Balance';
+import { fetchBNBBalance } from '../../tests/utils/fetchBNBBalance';
+import { waitSequential } from '../../tests/utils/waitSequential';
+import {
+  BEP20TransactionsFailed,
+  BEP20TransactionsReceived,
+  BNBTransactionsReceived,
+  BEP20AmountsReceived,
+  BEP20AmountsFailed,
+  BNBAmountsReceived,
+  BNBAmountsFailed,
+} from '.';
+import { selectUserBEP20Tokens } from './selectors';
+import { UserBEP20TokensInfo } from '@models/transactions';
 
 function* watchFetchContracts() {
   yield all([
@@ -11,6 +34,54 @@ function* watchFetchContracts() {
   ]);
 }
 
+function* watchRequestAmount() {
+  yield all([
+    takeLatest([BEP20TransactionsReceived.type], requestBEP20Amount),
+    takeLatest(
+      [BEP20TransactionsReceived.type, BNBTransactionsReceived.type],
+      requestBNBAmount,
+    ),
+  ]);
+}
+
+const fetchBEP20TokensAmount = async (
+  userBEP20Tokens: string[],
+  address: string,
+) =>
+  waitSequential<Record<string, BigintIsh>>(
+    userBEP20Tokens.map((tok) => async (pre) => {
+      const bal = await fetchBEP20Balance(tok, address);
+      pre[tok] = JSBI.BigInt(bal.result);
+      return pre;
+    }),
+    Promise.resolve({}),
+    201,
+  );
+
+function* requestBEP20Amount() {
+  try {
+    const userBEP20Tokens: string[] = yield select(selectUserBEP20Tokens);
+    const address: string = yield select(selectAddress);
+    const tokensAmount: Record<string, BigintIsh> = yield call(
+      fetchBEP20TokensAmount,
+      userBEP20Tokens,
+      address,
+    );
+    yield put(BEP20AmountsReceived(tokensAmount));
+  } catch (e) {
+    yield put(BEP20AmountsFailed(e.message));
+  }
+}
+function* requestBNBAmount() {
+  try {
+    const address: string = yield select(selectAddress);
+    const { result }: { result: string } = yield call(fetchBNBBalance, address);
+    yield put(BNBAmountsReceived(JSBI.BigInt(result)));
+  } catch (e) {
+    yield put(BNBAmountsFailed(e.message));
+  }
+}
+
 export default function* rootSaga() {
-  yield all([watchFetchContracts()]);
+  yield all([watchFetchContracts(), watchRequestAmount()]);
 }

--- a/src/store/transactions/selectors.ts
+++ b/src/store/transactions/selectors.ts
@@ -7,7 +7,7 @@ import {
 import { createSelector } from 'reselect';
 
 import { selectUserBEP20TokensInfo } from './BEP20/selectors';
-import { selectRawBNBTransactions } from './BNB/selectors';
+import { selectUserBNBTokenInfo } from './BNB/selectors';
 import { selectRawInternalTransactions } from './internal/selectors';
 import type { UserInfo } from './types';
 export * from './BEP20/selectors';
@@ -20,21 +20,6 @@ export const selectContractAddresses = createSelector(
   selectUserBEP20TokensInfo,
   (userBEP20TokensInfo: UserBEP20TokensInfo) =>
     Object.keys(userBEP20TokensInfo.tokens),
-);
-
-export const selectUserBNBTokenInfo = createSelector(
-  selectRawBNBTransactions,
-  selectRawInternalTransactions,
-  selectAddress,
-  (BNBTxns, internalTxns, address) => {
-    const result = parseBNBTransactions(BNBTxns, address);
-    result.amount = JSBI.add(
-      parseBigintIsh(result.amount),
-      parseBigintIsh(parseInternalTransactions(internalTxns, address).amount),
-    );
-    // no fees in internal transactions
-    return result;
-  },
 );
 
 export const selectUserInfo = createSelector(

--- a/src/tests/utils/waitSequential.ts
+++ b/src/tests/utils/waitSequential.ts
@@ -1,13 +1,14 @@
 export function waitSequential<T>(
   thunks: ((s: T) => Promise<T>)[],
   initialValue: Promise<T>,
+  timeBetween = 1000,
 ): Promise<T> {
   const delay = (time: number) =>
     function <V>(data: V) {
       return new Promise<V>((res) => setTimeout(() => res(data), time));
     };
   return thunks.reduce(
-    (pre, cur) => pre.then(delay(1000)).then(cur),
+    (pre, cur) => pre.then(delay(timeBetween)).then(cur),
     initialValue,
   );
 }


### PR DESCRIPTION
Before: parse a list of transactions (buggy). This will be continued in the future.
Now: fetch directly from account and contract address.

Solves #4.